### PR TITLE
refactor: drop keys when token expires

### DIFF
--- a/wework.go
+++ b/wework.go
@@ -2,14 +2,15 @@ package wework
 
 import (
 	"encoding/json"
+	"net/url"
+	"os"
+
 	badger "github.com/dgraph-io/badger/v3"
 	"github.com/go-laoji/wecom-go-sdk/v2/internal"
 	"github.com/go-resty/resty/v2"
 	"go.uber.org/zap"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
-	"net/url"
-	"os"
 )
 
 type IWeWork interface {
@@ -311,7 +312,7 @@ func NewWeWork(c WeWorkConfig) IWeWork {
 		var biz internal.BizResponse
 		json.Unmarshal(r.Body(), &biz)
 		if biz.ErrCode == 42001 {
-			ww.cache.DropAll()
+			ww.cache.DropPrefix([]byte("corpToken"))
 			return true
 		}
 		return false


### PR DESCRIPTION
仅清空企业token
[wecom-go-sdk/issues/13](https://github.com/go-laoji/wecom-go-sdk/issues/13#issuecomment-2309673584)